### PR TITLE
Firewalld and TcpWrappers Controls

### DIFF
--- a/controls/V-72047.rb
+++ b/controls/V-72047.rb
@@ -20,6 +20,12 @@ uri: http://iase.disa.mil
 -----------------
 =end
 
+WW_DIR_GROUPS = attribute(
+  'ww_dir_groups',
+  default: ['root', 'sys', 'bin'],
+  description: "File systems found in RHEL7 that don't correspond to removable media"
+)
+
 control "V-72047" do
   title "All world-writable directories must be group-owned by root, sys, bin, or an
 application group."
@@ -61,21 +67,11 @@ following command:
 
 # chgrp root <directory>"
 
-  # @todo - add option for app group associated with dir?
   ww_dirs = command('find / -xdev -perm -002 -type d -exec ls -ld {} \;').stdout.split("\n")
   ww_dirs.each do |curr_dir|
     dir_arr = curr_dir.split(' ')
-    # replace with be_in matcher
-    describe.one do
-      describe file(dir_arr.last) do
-        its('group') { should cmp "root" }
-      end
-      describe file(dir_arr.last) do
-        its('group') { should cmp "sys" }
-      end
-      describe file(dir_arr.last) do
-        its('group') { should cmp "bin" }
-      end
+    describe file(dir_arr.last) do
+      its('group') { should be_in WW_DIR_GROUPS }
     end
   end
 end

--- a/controls/V-72047.rb
+++ b/controls/V-72047.rb
@@ -20,10 +20,10 @@ uri: http://iase.disa.mil
 -----------------
 =end
 
-WW_DIR_GROUPS = attribute(
+ww_dir_groups = attribute(
   'ww_dir_groups',
   default: ['root', 'sys', 'bin'],
-  description: "File systems found in RHEL7 that don't correspond to removable media"
+  description: "Groups world-writeable directories are allowed to be owned by"
 )
 
 control "V-72047" do
@@ -67,11 +67,11 @@ following command:
 
 # chgrp root <directory>"
 
-  ww_dirs = command('find / -xdev -perm -002 -type d -exec ls -ld {} \;').stdout.split("\n")
-  ww_dirs.each do |curr_dir|
+  @ww_dirs = command('find / -xdev -perm -002 -type d -exec ls -ld {} \;').stdout.split("\n")
+  @ww_dirs.each do |curr_dir|
     dir_arr = curr_dir.split(' ')
     describe file(dir_arr.last) do
-      its('group') { should be_in WW_DIR_GROUPS }
+      its('group') { should be_in ww_dir_groups }
     end
   end
 end

--- a/controls/V-72049.rb
+++ b/controls/V-72049.rb
@@ -69,11 +69,17 @@ user agreement for access to the account must specify that the local interactive
 user must log on to their account first and then switch the user to the application
 account with the correct option to gain the account’s environment variables."
 
-  file_lines = command('grep -i -s umask /home/*/.*').stdout.split("\n")
-  file_lines.each do |curr_line|
-    file_name = curr_line.split(':').first
-    describe command("grep -i umask #{file_name}") do
-      its('stdout.strip') { should match /^umask\s+.*077/}
+
+  @user_params = passwd.params
+  @user_params.each do |user_param|
+    if user_param['uid'].to_i >= 1000
+      @file_lines = command("grep -i -s bash #{user_param['home']}/.*").stdout.split("\n")
+      @file_lines.each do |curr_line|
+        @file_name = curr_line.split(':').first
+        describe file(@file_name) do
+          its('content') { should_not match /^umask\s+[0-6]{1,3}$/ }
+        end
+      end
     end
   end
 end

--- a/controls/V-72049.rb
+++ b/controls/V-72049.rb
@@ -69,7 +69,6 @@ user agreement for access to the account must specify that the local interactive
 user must log on to their account first and then switch the user to the application
 account with the correct option to gain the account’s environment variables."
 
-  # @todo - test for values more restrictive than 077
   file_lines = command('grep -i -s umask /home/*/.*').stdout.split("\n")
   file_lines.each do |curr_line|
     file_name = curr_line.split(':').first

--- a/controls/V-72061.rb
+++ b/controls/V-72061.rb
@@ -44,7 +44,6 @@ UUID=c274f65f    /var                    ext4    noatime,nobarrier        1 2
 If a separate entry for \"/var\" is not in use, this is a finding."
   tag "fix": "Migrate the \"/var\" path onto a separate file system."
 
-  # @todo fstab resource?
   # note: the directory resource is a symlink to the 'file' resource
   describe directory('/var') do
     it { should be_mounted }

--- a/controls/V-72219.rb
+++ b/controls/V-72219.rb
@@ -20,6 +20,31 @@ uri: http://iase.disa.mil
 -----------------
 =end
 
+FIREWALLD_SERVICES_DENY = attribute(
+  'firewalld_services_deny',
+  default: [],
+  description: "Services that firewalld should be configured to deny."
+)
+
+FIREWALLD_HOSTS_DENY = attribute(
+  'firewalld_hosts_deny',
+  default: [
+    # Example
+    # 'rule family="ipv4" source address="104.56.21.1/24" accept]'
+  ],
+  description: "Hosts that firewalld should be configured to deny."
+)
+
+FIREWALLD_PORTS_DENY = attribute(
+  'firewalld_ports_deny',
+  default: [
+    # Examples
+    # '12345/tcp',
+    # '23456/tcp'
+  ],
+  description: "Ports that firewalld should be configured to deny."
+)
+
 control "V-72219" do
   title "The host must be configured to prohibit or restrict the use of functions,
 ports, protocols, and/or services, as defined in the Ports, Protocols, and Services
@@ -81,4 +106,18 @@ or there are ports, protocols, or services that are prohibited by the PPSM Categ
 Assurance List (CAL), this is a finding."
   tag "fix": "Update the host's firewall settings and/or running services to comply
 with the PPSM CLSA for the site or program and the PPSM CAL."
+
+  if service('firewalld').running?
+    describe firewalld do
+      FIREWALLD_SERVICES_DENY.each do |serv|
+        it { should_not have_service_enabled_in_zone(serv) }
+      end
+      FIREWALLD_HOSTS_DENY.each do |rule|
+        it { should_not have_rule_enabled(rule) }
+      end
+      FIREWALLD_PORTS_DENY.each do |port|
+        it { should_not have_port_enabled_in_zone(port) }
+      end
+    end
+  end
 end

--- a/controls/V-72219.rb
+++ b/controls/V-72219.rb
@@ -20,13 +20,13 @@ uri: http://iase.disa.mil
 -----------------
 =end
 
-FIREWALLD_SERVICES_DENY = attribute(
+firewalld_services_deny = attribute(
   'firewalld_services_deny',
   default: [],
   description: "Services that firewalld should be configured to deny."
 )
 
-FIREWALLD_HOSTS_DENY = attribute(
+firewalld_hosts_deny = attribute(
   'firewalld_hosts_deny',
   default: [
     # Example
@@ -35,7 +35,7 @@ FIREWALLD_HOSTS_DENY = attribute(
   description: "Hosts that firewalld should be configured to deny."
 )
 
-FIREWALLD_PORTS_DENY = attribute(
+firewalld_ports_deny = attribute(
   'firewalld_ports_deny',
   default: [
     # Examples
@@ -43,6 +43,15 @@ FIREWALLD_PORTS_DENY = attribute(
     # '23456/tcp'
   ],
   description: "Ports that firewalld should be configured to deny."
+)
+
+iptable_rules = attribute(
+  'iptable_rules',
+  default: [
+    # Example
+    # '-P INPUT ACCEPT',
+  ],
+  description: "Iptable rules that should exist."
 )
 
 control "V-72219" do
@@ -109,14 +118,20 @@ with the PPSM CLSA for the site or program and the PPSM CAL."
 
   if service('firewalld').running?
     describe firewalld do
-      FIREWALLD_SERVICES_DENY.each do |serv|
+      firewalld_services_deny.each do |serv|
         it { should_not have_service_enabled_in_zone(serv) }
       end
-      FIREWALLD_HOSTS_DENY.each do |rule|
+      firewalld_hosts_deny.each do |rule|
         it { should_not have_rule_enabled(rule) }
       end
-      FIREWALLD_PORTS_DENY.each do |port|
+      firewalld_ports_deny.each do |port|
         it { should_not have_port_enabled_in_zone(port) }
+      end
+    end
+  elsif service('iptables').running?
+    describe iptables do
+      iptable_rules.each do |rule|
+        it { should have_rule(rule) }
       end
     end
   end

--- a/controls/V-72271.rb
+++ b/controls/V-72271.rb
@@ -67,8 +67,15 @@ Note: The command is to add a rule to the public zone.
 # firewall-cmd --direct --add-rule ipv4 filter IN_public_allow 0 -p tcp -m limit
 --limit 25/minute --limit-burst 100  -j ACCEPT"
 
-  describe command('firewall-cmd --direct --get-rule ipv4 filter IN_public_allow') do
-    its('stdout') { should match /--limit .+/ }
-    its('stdout') { should match /--limit-burst .+/ }
+  if service('firewalld').running?
+    describe command('firewall-cmd --direct --get-rule ipv4 filter IN_public_allow') do
+      its('stdout') { should match /--limit .+/ }
+      its('stdout') { should match /--limit-burst .+/ }
+    end
+  elsif service('iptables').running?
+    describe command('iptables -S') do
+      its('stdout') { should match /--limit .+/ }
+      its('stdout') { should match /--limit-burst .+/ }
+    end
   end
 end

--- a/controls/V-72271.rb
+++ b/controls/V-72271.rb
@@ -67,7 +67,6 @@ Note: The command is to add a rule to the public zone.
 # firewall-cmd --direct --add-rule ipv4 filter IN_public_allow 0 -p tcp -m limit
 --limit 25/minute --limit-burst 100  -j ACCEPT"
 
-  # @todo - firewall resource?
   describe command('firewall-cmd --direct --get-rule ipv4 filter IN_public_allow') do
     its('stdout') { should match /--limit .+/ }
     its('stdout') { should match /--limit-burst .+/ }

--- a/controls/V-72273.rb
+++ b/controls/V-72273.rb
@@ -20,6 +20,12 @@ uri: http://iase.disa.mil
 -----------------
 =end
 
+FIREWALL_APPLICATION = attribute(
+  'firewalld_application',
+  default: 'firewalld',
+  description: "Name of the firewall application being used by this system."
+)
+
 control "V-72273" do
   title "The operating system must enable an application firewall, if available."
   desc  "
@@ -78,10 +84,10 @@ Start the firewall via \"systemctl\" with the following command:
 
 # systemctl start firewalld"
 
-  describe package('firewalld') do
+  describe package(FIREWALL_APPLICATION) do
     it { should be_installed }
   end
-  describe systemd_service('firewalld.service') do
-    it { should_not be_running }
+  describe service(FIREWALL_APPLICATION) do
+    it { should be_running }
   end
 end

--- a/controls/V-72315.rb
+++ b/controls/V-72315.rb
@@ -146,7 +146,7 @@ rules for allowing specific services and hosts.
 If \"tcpwrappers\" is installed, configure the \"/etc/hosts.allow\" and
 \"/etc/hosts.deny\" to allow or deny access to specific hosts."
 
-  if service('firewalld').running? then
+  if service('firewalld').running?
     @default_zone = firewalld.default_zone
 
     describe firewalld.where{ zone = @default_zone } do

--- a/controls/V-72315.rb
+++ b/controls/V-72315.rb
@@ -20,45 +20,60 @@ uri: http://iase.disa.mil
 -----------------
 =end
 
-# These attributes must be updated to reflect expectations of particular system
+# These attributes must be filled in to reflect expectations of particular system
 FIREWALLD_SERVICES = attribute(
   'firewalld_services',
   default: [
-    'dhcpv6-client',
-    'ssh'
+    # Examples
+    # 'dhcpv6-client',
+    # 'ssh'
   ],
   description: "Services that firewalld should be configured to allow."
 )
 
 FIREWALLD_HOSTS_ALLOW = attribute(
   'firewalld_hosts_allow',
-  default: [],
+  default: [
+    # Example
+    # 'rule family="ipv4" source address="92.188.21.1/24" accept]'
+  ],
   description: "Hosts that firewalld should be configured to allow."
 )
 
 FIREWALLD_HOSTS_DENY = attribute(
   'firewalld_hosts_deny',
-  default: [],
+  default: [
+    # Example
+    # 'rule family="ipv4" source address="104.56.21.1/24" accept]'
+  ],
   description: "Hosts that firewalld should be configured to deny."
 )
 
 FIREWALLD_PORTS_ALLOW = attribute(
   'firewalld_ports_allow',
-  default: [],
+  default: [
+    # Examples
+    # '22/tcp',
+    # '4722/tcp'
+  ],
   description: "Ports that firewalld should be configured to allow."
 )
 
 FIREWALLD_PORTS_DENY = attribute(
   'firewalld_ports_deny',
-  default: [],
+  default: [
+    # Examples
+    # '12345/tcp',
+    # '23456/tcp'
+  ],
   description: "Ports that firewalld should be configured to deny."
 )
 
 TCPWRAPPERS_ALLOW = attribute(
   'tcpwrappers_allow',
   default: [
-    # Example below
-    #{ 'daemon' => 'ALL', 'client_list' => ['ALL'], 'options' => ['allow'] }
+    # Example
+    # { 'daemon' => 'ALL', 'client_list' => ['ALL'], 'options' => ['allow'] }
   ],
   description: "Allow rules from etc/hosts.allow."
 )
@@ -66,8 +81,8 @@ TCPWRAPPERS_ALLOW = attribute(
 TCPWRAPPERS_DENY = attribute(
   'tcpwrappers_deny',
   default: [
-    # Example below
-    #{ 'daemon' => 'vsftpd', 'client_list' => ['ALL'], 'options' => [] }
+    # Example
+    # { 'daemon' => 'vsftpd', 'client_list' => ['ALL'], 'options' => [] }
   ],
   description: "Allow rules from etc/hosts.allow."
 )

--- a/controls/V-72315.rb
+++ b/controls/V-72315.rb
@@ -40,15 +40,6 @@ FIREWALLD_HOSTS_ALLOW = attribute(
   description: "Hosts that firewalld should be configured to allow."
 )
 
-FIREWALLD_HOSTS_DENY = attribute(
-  'firewalld_hosts_deny',
-  default: [
-    # Example
-    # 'rule family="ipv4" source address="104.56.21.1/24" accept]'
-  ],
-  description: "Hosts that firewalld should be configured to deny."
-)
-
 FIREWALLD_PORTS_ALLOW = attribute(
   'firewalld_ports_allow',
   default: [
@@ -57,16 +48,6 @@ FIREWALLD_PORTS_ALLOW = attribute(
     # '4722/tcp'
   ],
   description: "Ports that firewalld should be configured to allow."
-)
-
-FIREWALLD_PORTS_DENY = attribute(
-  'firewalld_ports_deny',
-  default: [
-    # Examples
-    # '12345/tcp',
-    # '23456/tcp'
-  ],
-  description: "Ports that firewalld should be configured to deny."
 )
 
 TCPWRAPPERS_ALLOW = attribute(


### PR DESCRIPTION
Added and updated controls that deal with firewalld and tcpwrappers that are dependent on the firewalld and etc_hosts_allow/deny resources.

These resources are available in InSpec version 1.40+.