### PR TITLE
(SIMP-4258) Ensured git installation during acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -12,6 +12,9 @@ unless ENV['BEAKER_provision'] == 'no'
     else
       install_puppet
     end
+    # Install git, it's a dependency for all profiles
+    # Found this when experiencing https://github.com/chef/inspec/issues/1270
+    install_package(host, 'git')
   end
 end
 


### PR DESCRIPTION
- Experienced this https://github.com/chef/inspec/issues/1270
- Used a global package installation via beaker so git is installed,
  no matter what the nodeset

SIMP-4258 #close