### PR TITLE
fix typo

### DIFF
--- a/controls/V-72253.rb
+++ b/controls/V-72253.rb
@@ -44,7 +44,7 @@ The SSH service must be restarted for changes to take effect."
     # fail fast
     describe 'The `sshd_config` setting for `MACs`' do
     subject { @macs }
-      it 'should be explicity set and not commented out' do
+      it 'should be explicitly set and not commented out' do
         expect(subject).not_to be_nil
       end
     end


### PR DESCRIPTION
Small fix: Typo fix on 'explicitly'