### PR TITLE
V-72037 Optimization

### DIFF
--- a/controls/V-72037.rb
+++ b/controls/V-72037.rb
@@ -80,7 +80,7 @@ files with the following command:
     #For each user, build and execute a find command that identifies initialization files
     #in a user's home directory.
     u.each do |user|
-      dotfiles = dotfiles + command("find #{user.home} -xdev -maxdepth 2 -name '.*' -type f").stdout.split("\n")
+      dotfiles = dotfiles + command("find #{user.home} -xdev -maxdepth 2 ( -name '.*' ! -name '.bash_history' ) -type f").stdout.split("\n")
     end
     ww_files = Set[]
     ww_files = command('find / -xdev -perm -002 -type f -exec ls {} \;').stdout.lines

--- a/controls/V-72037.rb
+++ b/controls/V-72037.rb
@@ -20,7 +20,8 @@ non_interactive_shells = attribute(
 )
 
 control "V-72037" do
-  title "Local initialization files must not execute world-writable programs."
+    title "The Red Hat Enterprise Linux operating system must be configured so
+ that local initialization files do not execute world-writable programs."
   if disable_slow_controls
     desc "This control consistently takes a long to run and has been disabled
           using the disable_slow_controls attribute."
@@ -45,12 +46,12 @@ world-writable programs.
 
 Check the system for world-writable files with the following command:
 
-# find / -perm -002 -type f -exec ls -ld {} \\; | more
+# find / -xdev -perm -002 -type f -exec ls -ld {} \\; | more
 
 For all files listed, check for their presence in the local initialization
 files with the following commands:
 
-Note: The example will be for a system that is configured to create users’ home
+Note: The example will be for a system that is configured to create users' home
 directories in the \"/home\" directory.
 
 # grep <file> /home/*/.*
@@ -82,7 +83,7 @@ files with the following command:
       dotfiles = dotfiles + command("find #{user.home} -xdev -maxdepth 2 -name '.*' -type f").stdout.split("\n")
     end
     ww_files = Set[]
-    ww_files = command('find / -perm -002 -type f -exec ls {} \;').stdout.lines
+    ww_files = command('find / -xdev -perm -002 -type f -exec ls {} \;').stdout.lines
     #Check each dotfile for existence of each world-writeable file
     findings = Set[]
     dotfiles.each do |dotfile|

--- a/controls/V-72037.rb
+++ b/controls/V-72037.rb
@@ -88,7 +88,9 @@ files with the following command:
     #To reduce the number of commands ran, we use a pattern file in the grep command below
     #So we don't have too long of a grep command, we chunk the list of ww_files
     #into strings not longer than PATTERN_FILE_MAX_LENGTH
-    PATTERN_FILE_MAX_LENGTH=100000
+    #Based on MAX_ARG_STRLEN, /usr/include/linux/binfmts.h
+    #We cut off 100 to leave room for the rest of the arguments
+    PATTERN_FILE_MAX_LENGTH=command("getconf PAGE_SIZE").stdout.to_i * 32 - 100
     ww_chunked=[""]
     ww_files.each do |item|
       item = item.strip

--- a/controls/V-72037.rb
+++ b/controls/V-72037.rb
@@ -86,11 +86,11 @@ files with the following command:
     ww_files = command('find / -xdev -perm -002 -type f -exec ls {} \;').stdout.lines
     #Check each dotfile for existence of each world-writeable file
     findings = Set[]
-    dotfiles.each do |dotfile|
-      dotfile = dotfile.strip
-      ww_files.each do |ww_file|
-        ww_file = ww_file.strip
-        count = command("grep -c \"#{ww_file}\" \"#{dotfile}\"").stdout.strip.to_i
+    unless ww_files.empty?
+      dotfiles.each do |dotfile|
+        dotfile = dotfile.strip
+        ww_combined = ww_files.map(&:strip).join("\n")
+        count = command("grep -c -f <(echo \"#{ww_combined}\") \"#{dotfile}\"").stdout.strip.to_i
         findings << dotfile if count > 0
       end
     end


### PR DESCRIPTION
I'm lumping a few things in this PR, let me know if you want me to remove some of the commits or separate them into separate PR's. I figured it'd be easier to have the discussion here.

V-72037 "Local initialization files must not execute world-writable programs."
This control was running really slowly. One of the big problems was that the find command was traversing the /proc directory, which would incorrectly include a lot of the processes attr files as potentially vulnerable world writable files. This was fixed in V2 of the RHEL7 STIG and is implemented in b0d7594.

Another problem was that the control would loop over every world-writable file and execute a grep command for each dot file in the users home directory. This was very slow ( O(m*n) ). Instead, we use process substitution to pass the list of world writable files to grep as a pattern file in 4968738.
In case this list is longer than the max command line length allowed on the system, 490a811 chunks the list into smaller pattern files, with a hard-coded limit of `PATTERN_FILE_MAX_LENGTH=100000`. Hard-coding this limit isn't ideal, let me know if this should be moved into an attribute.

The last problem is the fact that .bash_history is included as part of the users dot files. This means that running `ls` or any other command on a world-writable file will cause a false positive (if bash history is turned on). b0d7594 attempts to fix this. Ex:
```
dan@xp:~/inspec-profile-disa_stig-el7$ inspec exec controls/V-72037.rb --target ssh://$host

Profile: tests from controls/V-72037.rb (tests from controls.V-72037.rb)
Version: (not specified)
Target:  ssh://ec2-user@3.94.160.170:22

  ✔  V-72037: The Red Hat Enterprise Linux operating system must be configured so
   that local initialization files do not execute world-writable programs.
     ✔  Local initialization files that are found to reference world-writable files should be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 1 successful, 0 failures, 0 skipped
dan@xp:~/inspec-profile-disa_stig-el7$ ssh rhel7
Last login: Wed Aug 21 18:20:29 2019 from c-73-225-229-140.hsd1.wa.comcast.net
[ec2-user@ip-172-30-0-118 ~]$ sudo touch /opt/worldwritable
[ec2-user@ip-172-30-0-118 ~]$ sudo chmod a+rw /opt/worldwritable
[ec2-user@ip-172-30-0-118 ~]$ exit
logout
Connection to 3.94.160.170 closed.
dan@xp:~/inspec-profile-disa_stig-el7$ inspec exec controls/V-72037.rb --target ssh://$host

Profile: tests from controls/V-72037.rb (tests from controls.V-72037.rb)
Version: (not specified)
Target:  ssh://ec2-user@3.94.160.170:22

  ×  V-72037: The Red Hat Enterprise Linux operating system must be configured so
   that local initialization files do not execute world-writable programs.
     ×  Local initialization files that are found to reference world-writable files should be empty
     expected `["/home/ec2-user/.bash_history"].empty?` to return true, got false


Profile Summary: 0 successful controls, 1 control failure, 0 controls skipped
Test Summary: 0 successful, 1 failure, 0 skipped
dan@xp:~/inspec-profile-disa_stig-el7$ ssh rhel7 tail -n 3 .bash_history
rm /opt/worldwritable
sudo rm /opt/worldwritable
ls
dan@xp:~/inspec-profile-disa_stig-el7$ sed -i.bak 's/dotfiles = dotfiles.*/dotfiles = dotfiles + command("find #{user.home} -xdev -maxdepth 2 \( -name '\''.*'\'' ! -name '\''.bash_history'\'' \) -type f").stdout.split("\\n")/' controls/V-72037.rb
dan@xp:~/inspec-profile-disa_stig-el7$ inspec exec controls/V-72037.rb --target ssh://$host

Profile: tests from controls/V-72037.rb (tests from controls.V-72037.rb)
Version: (not specified)
Target:  ssh://ec2-user@3.94.160.170:22

  ✔  V-72037: The Red Hat Enterprise Linux operating system must be configured so
   that local initialization files do not execute world-writable programs.
     ✔  Local initialization files that are found to reference world-writable files should be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 1 successful, 0 failures, 0 skipped
```

With these fixes, the time for this control on a test system went down from 30 min to about a minute. So if this looks good, I can add another commit to remove it from the "slow control" group.