### PR TITLE
Update V-71961.rb

### DIFF
--- a/controls/V-71961.rb
+++ b/controls/V-71961.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
-grub_superusers = input(
-  'grub_superusers',
+grub_superuser = input(
+  'grub_superuser',
   description: 'superusers for grub boot ( array )',
   value: ['root']
 )


### PR DESCRIPTION
Input name doesn't match when it is used (grub_superusers vs. grub_superuser). Fixing the typo.