### PR TITLE
Fixing 72223 to correctly handle the collection of TMOUT

### DIFF
--- a/controls/V-72223.rb
+++ b/controls/V-72223.rb
@@ -68,18 +68,17 @@ readonly TMOUT
 export TMOUT"
   tag "fix_id": "F-78577r4_fix"
 
-  bashrc_file = parse_config_file('/etc/bashrc')
-
-  describe.one do
-    describe bashrc_file do
-      its('TMOUT') { should cmp <= system_activity_timeout }
-    end
-
-    profiled_files = command("find /etc/profile.d/*").stdout.split("\n")
-    profiled_files.each do |file|
-      profile_file = parse_config_file(file)
-      describe profile_file do
-        its('TMOUT') { should cmp <= system_activity_timeout }
+  files = ['/etc/bashrc'] + command("find /etc/profile.d/*").stdout.split("\n")
+  files.each do |file|
+    if (!(val = parse_config_file(file).params['TMOUT']).nil?)
+      describe"The TMOUT setting is configured properly in #{file}" do
+        subject { val.to_i }
+        it { should be <= system_activity_timeout }
+      end
+    else
+      describe "The TMOUT setting should be configured in #{file}" do
+        subject { !val.nil? }
+        it { should be true }
       end
     end
   end

--- a/controls/V-72223.rb
+++ b/controls/V-72223.rb
@@ -79,7 +79,7 @@ export TMOUT"
 
   files.each do |file|
     readonly = false
-    index = 0
+    
     # Skip to next file if TMOUT isn't present. Otherwise, get the last occurrence of TMOUT                                                                 
     next if (values = command("grep -Po '.*TMOUT.*' #{file}").stdout.split("\n")).empty?
 

--- a/controls/V-72223.rb
+++ b/controls/V-72223.rb
@@ -88,7 +88,7 @@ export TMOUT"
 
       # Skip if starts with '#' - it represents a comment                                                                                                    
       next if !value.match(/^#/).nil?
-  # If readonly and value is inline - use that value                                                                                                     
+      # If readonly and value is inline - use that value                                                                                                     
       if !value.match(/^readonly[\s]+TMOUT[\s]*=[\s]*[\d]+$/).nil?
         latest_val = value.match(/[\d]+/)[0].to_i
         readonly = true

--- a/controls/V-72223.rb
+++ b/controls/V-72223.rb
@@ -70,15 +70,15 @@ export TMOUT"
 
   files = ['/etc/bashrc'] + command("find /etc/profile.d/*").stdout.split("\n")
   files.each do |file|
-    if (!(val = parse_config_file(file).params['TMOUT']).nil?)
-      describe"The TMOUT setting is configured properly in #{file}" do
-        subject { val.to_i }
-        it { should be <= system_activity_timeout }
-      end
-    else
+    if ((val = parse_config_file(file).params['TMOUT']).nil?)
       describe "The TMOUT setting should be configured in #{file}" do
         subject { !val.nil? }
         it { should be true }
+      end
+    else
+      describe"The TMOUT setting is configured properly in #{file}" do
+        subject { val.to_i }
+        it { should be <= system_activity_timeout }
       end
     end
   end

--- a/controls/V-72223.rb
+++ b/controls/V-72223.rb
@@ -68,18 +68,59 @@ readonly TMOUT
 export TMOUT"
   tag "fix_id": "F-78577r4_fix"
 
-  files = ['/etc/bashrc'] + command("find /etc/profile.d/*").stdout.split("\n")
+  # Get current TMOUT environment variable (active test)                                                                                                     
+  describe os_env('TMOUT') do
+    its('content') { should be <= system_activity_timeout }
+  end
+
+  # Check if TMOUT is set in files (passive test)                                                                                                            
+  files = ['/etc/bashrc'] + ['/etc/profile'] + command("find /etc/profile.d/*").stdout.split("\n")
+  latest_val = nil
+
   files.each do |file|
-    if ((val = parse_config_file(file).params['TMOUT']).nil?)
-      describe "The TMOUT setting should be configured in #{file}" do
-        subject { !val.nil? }
-        it { should be true }
+    readonly = false
+    index = 0
+    # Skip to next file if TMOUT isn't present. Otherwise, get the last occurrence of TMOUT                                                                 
+    next if (values = command("grep -Po '.*TMOUT.*' #{file}").stdout.split("\n")).empty?
+
+    # Loop through each TMOUT match and see if set TMOUT's value or makes it readonly                                                                        
+    values.each_with_index { |value, index|
+
+      # Skip if starts with '#' - it represents a comment                                                                                                    
+      next if !value.match(/^#/).nil?
+  # If readonly and value is inline - use that value                                                                                                     
+      if !value.match(/^readonly[\s]+TMOUT[\s]*=[\s]*[\d]+$/).nil?
+        latest_val = value.match(/[\d]+/)[0].to_i
+        readonly = true
+        break
+      # If readonly, but, value is not inline - use the most recent value                                                                                    
+      elsif !value.match(/^readonly[\s]+([\w]+[\s]+)?TMOUT[\s]*([\s]+[\w]+[\s]*)*$/).nil?
+        # If the index is greater than 0, the configuraiton setting value.                                                                                   
+        # Otherwise, the configuration setting value is in the previous file                                                                                 
+        # and is already set in latest_val.                                                                                                                  
+        if index >= 1
+          latest_val = values[index - 1].match(/[\d]+/)[0].to_i
+        end
+        readonly = true
+        break
+      # Readonly is not set use the lastest value                                                                                                            
+      else
+        latest_val = value.match(/[\d]+/)[0].to_i
       end
-    else
-      describe"The TMOUT setting is configured properly in #{file}" do
-        subject { val.to_i }
-        it { should be <= system_activity_timeout }
-      end
+    }
+   # Readonly is set - stop processing files                                                                                                                
+    break if readonly === true
+  end
+
+  if latest_val.nil?
+    describe "The TMOUT setting is configured" do
+      subject { !latest_val.nil? }
+      it { should be true }
+    end
+  else
+    describe"The TMOUT setting is configured properly" do
+      subject { latest_val }
+      it { should be <= system_activity_timeout }
     end
   end
 end


### PR DESCRIPTION
Fixed a bug in 72223 where it was reporting a value of nil when the configuration setting was not set in a file. The code now reports that the configuration setting is not configured in the specific file.