### PR TITLE
add platform support to the inspec example

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -7,6 +7,9 @@ license: Apache-2.0
 summary: 'The `disa_stig-el7` inspec profile helps scan your system aginst the DISA RHEL7 STIG'
 version: 0.2.0
 
+- platform-name: redhat
+  release: 7
+
 # The following defines the default inputs for the configurable controls used in the RHEL 7 DISA STIG.
 inputs:
 - name: disable_slow_controls

--- a/inspec.yml
+++ b/inspec.yml
@@ -7,8 +7,9 @@ license: Apache-2.0
 summary: 'The `disa_stig-el7` inspec profile helps scan your system aginst the DISA RHEL7 STIG'
 version: 0.2.0
 
-- platform-name: redhat
-  release: 7
+supports:
+  - platform-name: redhat
+    release: 7
 
 # The following defines the default inputs for the configurable controls used in the RHEL 7 DISA STIG.
 inputs:


### PR DESCRIPTION
This will allow us to use a wrapper profile correctly between platforms