### PR TITLE
Addressing issue #129

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -286,8 +286,8 @@ inputs:
 
 - name: grub_superuser
   description: superusers for grub boot
-  type: Array
-  value: ['root']
+  type: String
+  value: 'root'
 
 - name: grub_user_boot_files
   description: Grub boot config files


### PR DESCRIPTION
Removed 'grub_superuser' as an input. The STIG guidance is clear that
this is the only allowable account so there is no reason to allow it
to be tailored.

Updated V-71961 to remove reference to the 'grub_superuser' input and
hardcode "grub_superuser = 'root'".

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>